### PR TITLE
test(Result): add failing tests for expected table headers

### DIFF
--- a/investment-calculator/src/components/Result.tsx
+++ b/investment-calculator/src/components/Result.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Result = () => {
+  return <div>Result</div>;
+};
+
+export default Result;

--- a/investment-calculator/src/components/Result.tsx
+++ b/investment-calculator/src/components/Result.tsx
@@ -1,7 +1,17 @@
-import React from "react";
-
 const Result = () => {
-  return <div>Result</div>;
+  return (
+    <table id="result">
+      <thead>
+        <tr>
+          <th>Year</th>
+          <th>Investment Value</th>
+          <th>Interest(Year)</th>
+          <th>Total Interest</th>
+          <th>Invested Capital</th>
+        </tr>
+      </thead>
+    </table>
+  );
 };
 
 export default Result;

--- a/investment-calculator/src/tests/__tests__/resuts.test.tsx
+++ b/investment-calculator/src/tests/__tests__/resuts.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import Result from "../../components/Result";
+
+describe("result component", () => {
+  beforeEach(() => {
+    render(<Result />);
+  });
+  test("table has been rendered with thead with 5 columns", () => {
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers).toHaveLength(5);
+  });
+  test("theads have the correct title in correct order", () => {
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers[0]).toHaveTextContent("Year");
+    expect(headers[1]).toHaveTextContent("Investment Value");
+    expect(headers[2]).toHaveTextContent("Interest(Year)");
+    expect(headers[3]).toHaveTextContent("Total Interest");
+    expect(headers[4]).toHaveTextContent("Invested Capital");
+  });
+});


### PR DESCRIPTION
These tests assert that the <Result /> component renders
a table with a thead containing 5 specific column headers.

They are expected to fail until the component is implemented.