### PR TITLE
Add min=0 to inputs and prevent negative values in onChange handler

### DIFF
--- a/investment-calculator/src/components/InvestmentForm.tsx
+++ b/investment-calculator/src/components/InvestmentForm.tsx
@@ -19,9 +19,11 @@ const InvestmentForm = () => {
   const onHandleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
     const valueAsNumber = Number(value);
+    // only used as fail safe this should never work as input min value is 0 and '-' key not accepted
+    const newValue = valueAsNumber < 0 ? 0 : valueAsNumber;
     setFormValues((prev) => ({
       ...prev,
-      [id]: valueAsNumber,
+      [id]: newValue,
     }));
   };
   return (


### PR DESCRIPTION
- Added min={0} to all number inputs to block negative entries
- Added fail-safe ternary operator in onChange to default negatives to 0 (should never actually trigger)