### PR TITLE
feat: add utility to calculate investment results

### DIFF
--- a/investment-calculator/src/util/investment.ts
+++ b/investment-calculator/src/util/investment.ts
@@ -1,9 +1,9 @@
-// This function expects an object as an argument
-// The object should contain the following properties
-// - initialInvestment: The initial investment amount
-// - annualInvestment: The amount invested every year
-// - expectedReturns: The expected (annual) rate of return
-// - duration: The investment duration (time frame)
+// Calculates the investment growth over a number of years.
+// Accepts an object with the following properties:
+// - initialInvestment: Initial amount of money invested
+// - annualInvestment: Fixed amount added every year
+// - expectedReturns: Annual return rate (as a percentage)
+// - duration: Number of years to invest
 
 import { FormValueProps } from "../components/InvestmentForm";
 
@@ -15,27 +15,31 @@ export function calculateInvestmentResults({
 }: FormValueProps) {
   const annualData = [];
   let investmentValue = initialInvestment;
-
+  let totalInterest = 0;
+  let totalInvested = initialInvestment;
   for (let i = 0; i < duration; i++) {
     const interestEarnedInYear = investmentValue * (expectedReturns / 100);
     investmentValue += interestEarnedInYear + annualInvestment;
+    totalInterest += interestEarnedInYear;
+    totalInvested += annualInvestment;
     annualData.push({
-      year: i + 1, // year identifier
-      interest: interestEarnedInYear, // the amount of interest earned in this year
-      valueEndOfYear: investmentValue, // investment value at end of year
-      annualInvestment: annualInvestment, // investment added in this year
+      year: i + 1, // Year number (1-based)
+      investmentValue: investmentValue, // Total value at end of this year
+      interestYear: interestEarnedInYear, // Interest earned this year
+      totalInterest: totalInterest, // Cumulative interest earned
+      investedCapital: totalInvested, // Cumulative amount invested
     });
   }
 
   return annualData;
 }
 
-// The browser-provided Intl API is used to prepare a formatter object
-// This object offers a "format()" method that can be used to format numbers as currency
-// Example Usage: formatter.format(1000) => yields "$1,000"
-export const formatter = new Intl.NumberFormat("en-US", {
+// Prepares a currency formatter for British Pounds using the built-in Intl API.
+// Use formatter.format(number) to format values as GBP.
+// Example: formatter.format(1000) => "£1,000"
+export const formatter = new Intl.NumberFormat("en-GB", {
   style: "currency",
-  currency: "USD",
+  currency: "GBP",
   minimumFractionDigits: 0,
   maximumFractionDigits: 0,
 });

--- a/investment-calculator/src/util/investment.ts
+++ b/investment-calculator/src/util/investment.ts
@@ -1,0 +1,41 @@
+// This function expects an object as an argument
+// The object should contain the following properties
+// - initialInvestment: The initial investment amount
+// - annualInvestment: The amount invested every year
+// - expectedReturns: The expected (annual) rate of return
+// - duration: The investment duration (time frame)
+
+import { FormValueProps } from "../components/InvestmentForm";
+
+export function calculateInvestmentResults({
+  initialInvestment,
+  annualInvestment,
+  expectedReturns,
+  duration,
+}: FormValueProps) {
+  const annualData = [];
+  let investmentValue = initialInvestment;
+
+  for (let i = 0; i < duration; i++) {
+    const interestEarnedInYear = investmentValue * (expectedReturns / 100);
+    investmentValue += interestEarnedInYear + annualInvestment;
+    annualData.push({
+      year: i + 1, // year identifier
+      interest: interestEarnedInYear, // the amount of interest earned in this year
+      valueEndOfYear: investmentValue, // investment value at end of year
+      annualInvestment: annualInvestment, // investment added in this year
+    });
+  }
+
+  return annualData;
+}
+
+// The browser-provided Intl API is used to prepare a formatter object
+// This object offers a "format()" method that can be used to format numbers as currency
+// Example Usage: formatter.format(1000) => yields "$1,000"
+export const formatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});


### PR DESCRIPTION
first commit:  add utility to calculate investment results
- Adds a calculateInvestmentResults function that computes yearly investment growth.
- It accepts an object with initialInvestment, annualInvestment, expectedReturns, and duration.
- Also includes a formatter using Intl.NumberFormat for currency display.

second commit: : refine investment result structure and switch to GBP formatting
- Updated calculation logic to include total interest, interest per year, invested capital, and end-of-year value per year.
- Ensured output aligns with table display expectations.
- Changed currency formatting from USD to GBP using en-GB locale.