### PR TITLE
fix: add max={100} to Duration input to prevent page hang on large values

### DIFF
--- a/investment-calculator/src/components/InvestmentForm.tsx
+++ b/investment-calculator/src/components/InvestmentForm.tsx
@@ -62,6 +62,7 @@ const InvestmentForm = ({
               id="duration"
               type="number"
               min={0}
+              max={100}
               required
               value={String(duration)}
               onChange={(e) => onHandleChange(e)}


### PR DESCRIPTION
Added max={100} to the Duration input field to limit inputs to 100 years, preventing page hangs caused by excessively large values. This safeguard improves UI stability and user experience.



