### PR TITLE
test(sideBar):add failing test for sidebar project list rendering

### DIFF
--- a/project-manager/src/App.tsx
+++ b/project-manager/src/App.tsx
@@ -4,6 +4,13 @@ import NoProject from "./components/NoProject";
 import SelectedProject from "./components/SelectedProject";
 import SideBar from "./components/SideBar";
 
+export type ProjectProps = {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  tasks: string[];
+};
 const projects = [
   {
     id: "1",
@@ -39,7 +46,7 @@ export default function App() {
 
       <div className="flex h-svh pt-6">
         {/* Sidebar: shows list of projects to select from */}
-        <SideBar onAddProject={onAddProject} />
+        <SideBar onAddProject={onAddProject} projectsList={projects} />
 
         {/* Main content
           no project compontent on initial render */}

--- a/project-manager/src/components/SideBar.tsx
+++ b/project-manager/src/components/SideBar.tsx
@@ -1,9 +1,11 @@
+import { ProjectProps } from "../App";
 import { AddProjectButton } from "./InputsAndButtons/AddProjectButton";
 
 type SideBarProps = {
   onAddProject: () => void;
+  projectsList: ProjectProps[];
 };
-const SideBar = ({ onAddProject }: SideBarProps) => {
+const SideBar = ({ onAddProject, projectsList }: SideBarProps) => {
   return (
     <aside className="w-1/3 px-8 py-16 bg-stone-900  md:w-72 rounded-tr-2xl">
       <h2 className="mb-8 text-stone-200 text-xl font-bold uppercase ">

--- a/project-manager/src/tests/sidebar.test.tsx
+++ b/project-manager/src/tests/sidebar.test.tsx
@@ -2,6 +2,31 @@ import { screen, render } from "@testing-library/react";
 import SideBar from "../components/SideBar";
 import userEvent from "@testing-library/user-event";
 
+let mockProjects = [
+  {
+    id: "1",
+    title: "New project",
+    description: "Description will be here",
+    date: "12/03/25",
+    tasks: ["task 1"],
+  },
+  {
+    id: "2",
+    title: "New project 2",
+    description: " Description will be here",
+    date: "12/03/25",
+    tasks: ["task "],
+  },
+  {
+    id: "3",
+    title: "New project 3",
+    description: " Description will be here",
+    date: "12/03/25",
+    tasks: ["task "],
+  },
+];
+
+const mockAddProject = vi.fn();
 export const getSideBarElements = () => {
   return {
     sidebar: screen.getByRole("complementary"),
@@ -14,18 +39,22 @@ const user = userEvent.setup();
 
 describe("Sidebar Component", () => {
   test("aside, h2, and button should be rendered, with correct content", () => {
-    render(<SideBar />);
+    render(
+      <SideBar onAddProject={mockAddProject} projectsList={mockProjects} />
+    );
     const { sidebar, sideBarh2, sideBarButton } = getSideBarElements();
     expect(sidebar).toBeInTheDocument();
     expect(sideBarh2).toBeInTheDocument();
     expect(sideBarButton).toBeInTheDocument();
   });
-  // test("button should fire handleNewProject on click", async () => {
-  //   const handleNewProject = vi.fn(); // or jest.fn() if using Jest
-
-  //   render(<SideBar handleNewProject={handleNewProject} />);
-  //   const { sideBarButton } = getSideBarElements();
-  //   await user.click(sideBarButton);
-  //   expect(handleNewProject).toHaveBeenCalled();
-  // });
+  test("projects title should be displayed as link to slected task", () => {
+    const projectList = screen.getByRole("list");
+    expect(projectList).toHaveLength(3);
+    const project1 = screen.getByText("New project 1");
+    const project2 = screen.getByText("New project 2");
+    const project3 = screen.getByText("New project 3");
+    expect(project1).toBeInTheDocument();
+    expect(project2).toBeInTheDocument();
+    expect(project3).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Wrote test to expect 3 list items based on mock data.
- Verified each item contains its project title.
- Sidebar does not yet render the list — test fails as expected.